### PR TITLE
Fix cross-building

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -36,8 +36,9 @@ object Common extends AutoPlugin {
           <url>http://www.tecsisa.com</url>
         </developer>
       </developers>,
-    scalaVersion := Version.Scala,
-    crossScalaVersions := Vector(scalaVersion.value, "2.11.8"),
+    scalaVersion := Version.ScalaVersions.head,
+    crossScalaVersions := Version.ScalaVersions,
+    crossVersion := CrossVersion.binary,
     scalacOptions ++= Vector(
       "-unchecked",
       "-deprecation",
@@ -59,7 +60,6 @@ object Common extends AutoPlugin {
 
     // scalafmt settings
     formatSbtFiles := false,
-    scalafmtConfig := Some(baseDirectory.in(ThisBuild).value / ".scalafmt.conf"),
-    ivyScala := ivyScala.value.map(_.copy(overrideScalaVersion = sbtPlugin.value)) // TODO Remove once this workaround no longer needed (https://github.com/sbt/sbt/issues/2786)!
+    scalafmtConfig := Some(baseDirectory.in(ThisBuild).value / ".scalafmt.conf")
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Version {
   final val ConstructrAkka   = "0.15.0"
   final val Log4j            = "2.7"
   final val Circe            = "0.6.1"
-  final val Scala            = "2.12.1"
+  final val ScalaVersions    = Seq("2.12.1", "2.11.8")
   final val ScalaTest        = "3.0.1"
 }
 


### PR DESCRIPTION
`scalaVersion.value` is dynamic so that when SBT is bulding the project for Scala 2.11.8, the setting `crossScalaVersions` will be (2.11.8, 2.11.8). Now, `Version.ScalaVersions` set a fixed value for that.